### PR TITLE
chore: commit YARPP related-posts templates from prod

### DIFF
--- a/yarpp-template-example.php
+++ b/yarpp-template-example.php
@@ -1,0 +1,40 @@
+<?php
+/*
+YARPP Template: Starter Template
+Description: A simple starter example template that you can edit.
+Author: YARPP Team
+*/
+?>
+
+<?php
+/*
+Templating in YARPP enables developers to uber-customize their YARPP display using PHP and template tags.
+
+The tags we use in YARPP templates are the same as the template tags used in any WordPress template. In fact, any WordPress template tag will work in the YARPP Loop. You can use these template tags to display the excerpt, the post date, the comment count, or even some custom metadata. In addition, template tags from other plugins will also work.
+
+If you've ever had to tweak or build a WordPress theme before, you’ll immediately feel at home.
+
+// Special template tags which only work within a YARPP Loop:
+
+1. the_score()		// this will print the YARPP match score of that particular related post
+2. get_the_score()		// or return the YARPP match score of that particular related post
+
+Notes:
+1. If you would like Pinterest not to save an image, add `data-pin-nopin="true"` to the img tag.
+
+*/
+?>
+
+<h3>Related Posts</h3>
+<?php if ( have_posts() ) : ?>
+<ul>
+	<?php
+	while ( have_posts() ) :
+		the_post();
+		?>
+	<li><a href="<?php the_permalink(); ?>" rel="bookmark norewrite" title="<?php the_title_attribute(); ?>" ><?php the_title(); ?></a><!-- (<?php the_score(); ?>)--></li>
+	<?php endwhile; ?>
+</ul>
+<?php else : ?>
+<p>No related posts.</p>
+<?php endif; ?>

--- a/yarpp-template-list.php
+++ b/yarpp-template-list.php
@@ -1,0 +1,43 @@
+<?php
+/*
+YARPP Template: List
+Description: This template returns posts as a comma-separated list.
+Author: YARPP Team
+*/
+?>
+
+<?php
+/*
+Templating in YARPP enables developers to uber-customize their YARPP display using PHP and template tags.
+
+The tags we use in YARPP templates are the same as the template tags used in any WordPress template. In fact, any WordPress template tag will work in the YARPP Loop. You can use these template tags to display the excerpt, the post date, the comment count, or even some custom metadata. In addition, template tags from other plugins will also work.
+
+If you've ever had to tweak or build a WordPress theme before, you’ll immediately feel at home.
+
+// Special template tags which only work within a YARPP Loop:
+
+1. the_score()		// this will print the YARPP match score of that particular related post
+2. get_the_score()		// or return the YARPP match score of that particular related post
+
+Notes:
+1. If you would like Pinterest not to save an image, add `data-pin-nopin="true"` to the img tag.
+
+*/
+?>
+
+<h3>Related Posts</h3>
+<?php
+if ( have_posts() ) :
+	$postsArray = array();
+	while ( have_posts() ) :
+		the_post();
+		$postsArray[] = '<a href="' . get_permalink() . '" rel="bookmark norewrite" title="' . the_title_attribute( 'echo=0' ) . '">' . get_the_title() . '</a><!-- (' . get_the_score() . ')-->';
+	endwhile;
+
+	echo implode( ', ' . "\n", $postsArray ); // print out a list of the related items, separated by commas
+
+else :
+	?>
+
+<p>No related posts.</p>
+<?php endif; ?>

--- a/yarpp-template-multilingual.php
+++ b/yarpp-template-multilingual.php
@@ -1,0 +1,46 @@
+<?php
+/*
+YARPP Template: Multilingual
+Description: An example template for use with the WPML and Polylang plugins
+Author: YARPP Team
+*/
+?>
+
+<?php
+/*
+Templating in YARPP enables developers to uber-customize their YARPP display using PHP and template tags.
+
+The tags we use in YARPP templates are the same as the template tags used in any WordPress template. In fact, any WordPress template tag will work in the YARPP Loop. You can use these template tags to display the excerpt, the post date, the comment count, or even some custom metadata. In addition, template tags from other plugins will also work.
+
+If you've ever had to tweak or build a WordPress theme before, you’ll immediately feel at home.
+
+// Special template tags which only work within a YARPP Loop:
+
+1. the_score()		// this will print the YARPP match score of that particular related post
+2. get_the_score()		// or return the YARPP match score of that particular related post
+
+Notes:
+1. If you would like Pinterest not to save an image, add `data-pin-nopin="true"` to the img tag.
+
+*/
+?>
+
+<?php
+if ( function_exists( 'icl_register_string' ) ) {
+	icl_register_string( 'Yet Another Related Posts Plugin', 'related posts header', 'Related Posts' );
+	icl_register_string( 'Yet Another Related Posts Plugin', 'no related posts message', 'No related posts.' );
+}
+?>
+<div class="mt-5">
+	<p class="lead"><?php echo ( function_exists( 'icl_t' ) ? icl_t( 'Yet Another Related Posts Plugin', 'related posts header', 'Related Posts' ) : 'Related Posts' ); ?></p></div>
+<?php if ( have_posts() ) : ?>
+<div class="text-left">
+	<?php
+	while ( have_posts() ) :
+		the_post();
+		?>
+	<p><a href="<?php the_permalink(); ?>" rel="bookmark norewrite" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></p>
+	<?php endwhile; ?>
+</div>
+
+<?php endif; ?>

--- a/yarpp-template-photoblog.php
+++ b/yarpp-template-photoblog.php
@@ -1,0 +1,19 @@
+<?php
+/*
+YARPP Template: Yet Another Photoblog
+Description: Requires the Yet Another Photoblog plugin
+Author: YARPP Team
+*/ ?>
+<h3>Related Photos</h3>
+<?php if (have_posts()):?>
+<ol>
+	<?php while (have_posts()) : the_post(); ?>
+		<?php if (function_exists('yapb_is_photoblog_post')): if (yapb_is_photoblog_post()):?>
+		<li><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php yapb_get_thumbnail(); ?></a></li>
+		<?php endif; endif; ?>
+	<?php endwhile; ?>
+</ol>
+
+<?php else: ?>
+<p>No related photos.</p>
+<?php endif; ?>

--- a/yarpp-template-random.php
+++ b/yarpp-template-random.php
@@ -1,0 +1,45 @@
+<?php
+/*
+YARPP Template: Random Default
+Description: This template gives you a random other post in case there are no related posts
+Author: YARPP Team
+*/
+?>
+
+<?php
+/*
+Templating in YARPP enables developers to uber-customize their YARPP display using PHP and template tags.
+
+The tags we use in YARPP templates are the same as the template tags used in any WordPress template. In fact, any WordPress template tag will work in the YARPP Loop. You can use these template tags to display the excerpt, the post date, the comment count, or even some custom metadata. In addition, template tags from other plugins will also work.
+
+If you've ever had to tweak or build a WordPress theme before, you’ll immediately feel at home.
+
+// Special template tags which only work within a YARPP Loop:
+
+1. the_score()		// this will print the YARPP match score of that particular related post
+2. get_the_score()		// or return the YARPP match score of that particular related post
+
+Notes:
+1. If you would like Pinterest not to save an image, add `data-pin-nopin="true"` to the img tag.
+
+*/
+?>
+
+<h3>Related Posts</h3>
+<?php if ( have_posts() ) : ?>
+<ol>
+	<?php
+	while ( have_posts() ) :
+		the_post();
+		?>
+	<li><a href="<?php the_permalink(); ?>" rel="bookmark norewrite" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a><!-- (<?php the_score(); ?>)--></li>
+	<?php endwhile; ?>
+</ol>
+
+	<?php
+else :
+	query_posts( 'orderby=rand&order=asc&limit=1' );
+	the_post();
+	?>
+<p>No related posts were found, so here's a consolation prize: <a href="<?php the_permalink(); ?>" rel="bookmark norewrite" title="<?php the_title_attribute(); ?>><?php the_title(); ?></a>.</p>
+<?php endif; ?>

--- a/yarpp-template-simple.php
+++ b/yarpp-template-simple.php
@@ -1,0 +1,40 @@
+<?php
+/*
+YARPP Template: Simple List
+Description: This template returns posts in an unordered list.
+Author: YARPP Team
+*/
+?>
+
+<?php
+/*
+Templating in YARPP enables developers to uber-customize their YARPP display using PHP and template tags.
+
+The tags we use in YARPP templates are the same as the template tags used in any WordPress template. In fact, any WordPress template tag will work in the YARPP Loop. You can use these template tags to display the excerpt, the post date, the comment count, or even some custom metadata. In addition, template tags from other plugins will also work.
+
+If you've ever had to tweak or build a WordPress theme before, you’ll immediately feel at home.
+
+// Special template tags which only work within a YARPP Loop:
+
+1. the_score()		// this will print the YARPP match score of that particular related post
+2. get_the_score()		// or return the YARPP match score of that particular related post
+
+Notes:
+1. If you would like Pinterest not to save an image, add `data-pin-nopin="true"` to the img tag.
+
+*/
+?>
+
+<h3>Related Posts</h3>
+<?php if ( have_posts() ) : ?>
+<ul>
+	<?php
+	while ( have_posts() ) :
+		the_post();
+		?>
+	<li><a href="<?php the_permalink(); ?>" rel="bookmark norewrite" title="<?php the_title_attribute(); ?>" ><?php the_title(); ?></a><!-- (<?php the_score(); ?>)--></li>
+	<?php endwhile; ?>
+</ul>
+<?php else : ?>
+<p>No related posts.</p>
+<?php endif; ?>

--- a/yarpp-template-thumbnail.php
+++ b/yarpp-template-thumbnail.php
@@ -1,0 +1,53 @@
+<?php
+/*
+YARPP Template: Thumbnails
+Description: This template returns the related posts as thumbnails in an ordered list. Requires a theme which supports post thumbnails.
+Author: YARPP Team
+*/
+?>
+
+<?php
+/*
+Templating in YARPP enables developers to uber-customize their YARPP display using PHP and template tags.
+
+The tags we use in YARPP templates are the same as the template tags used in any WordPress template. In fact, any WordPress template tag will work in the YARPP Loop. You can use these template tags to display the excerpt, the post date, the comment count, or even some custom metadata. In addition, template tags from other plugins will also work.
+
+If you've ever had to tweak or build a WordPress theme before, you’ll immediately feel at home.
+
+// Special template tags which only work within a YARPP Loop:
+
+1. the_score()		// this will print the YARPP match score of that particular related post
+2. get_the_score()		// or return the YARPP match score of that particular related post
+
+Notes:
+1. If you would like Pinterest not to save an image, add `data-pin-nopin="true"` to the img tag.
+
+*/
+?>
+
+<?php
+/* Pick Thumbnail */
+global $_wp_additional_image_sizes;
+if ( isset( $_wp_additional_image_sizes['yarpp-thumbnail'] ) ) {
+	$dimensions['size'] = 'yarpp-thumbnail';
+} else {
+	$dimensions['size'] = 'medium'; // default
+}
+?>
+
+<h3>Related Photos</h3>
+<?php if ( have_posts() ) : ?>
+<ul>
+	<?php
+	while ( have_posts() ) :
+		the_post();
+		?>
+		<?php if ( has_post_thumbnail() ) : ?>
+		<li><a href="<?php the_permalink(); ?>" rel="bookmark norewrite" title="<?php the_title_attribute(); ?>"><?php the_post_thumbnail( $dimensions['size'], array( 'data-pin-nopin' => 'true' ) ); ?></a></li>
+		<?php endif; ?>
+	<?php endwhile; ?>
+</ul>
+
+<?php else : ?>
+<p>No related photos.</p>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
Commits 7 `yarpp-template-*.php` files that have existed in the live theme directory on the server but were never tracked in git.

While deploying the latest theme to s1, a diff of prod vs the repo showed these were the only **functional** files present on the server but missing from git (they back the YARPP "related posts" plugin). Committing them so:

- git reflects the full theme as actually deployed, and
- future automated deploys (see the companion CI PR) can run safely without dropping related-posts functionality.

## Files added
- `yarpp-template-example.php`
- `yarpp-template-list.php`
- `yarpp-template-multilingual.php`
- `yarpp-template-photoblog.php`
- `yarpp-template-random.php`
- `yarpp-template-simple.php`
- `yarpp-template-thumbnail.php`

## Not included
The other prod-only files were leftover Apache `.htaccess` files from the old cPanel host. nginx ignores `.htaccess` entirely (and the nginx config already denies access to dotfiles), so they are dead artifacts and were intentionally **not** committed. They remain on the server, harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)