### PR TITLE
ci: deploy theme to s1 on merge to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy theme to s1
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: {} # allow manual runs from the Actions tab
+
+# Never run two deploys at once; let an in-flight deploy finish.
+concurrency:
+  group: deploy-theme
+  cancel-in-progress: false
+
+env:
+  THEME_DIR: /root/data/legalizebelarus.org/wp-content/themes/legalizebelarus
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure SSH (lb-ci key)
+        run: |
+          mkdir -p ~/.ssh
+          install -m 600 /dev/null ~/.ssh/id_ed25519
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
+          ssh-keyscan -H "${{ secrets.DEPLOY_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Sync theme
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          # Additive sync (no --delete): never removes prod-only files such as
+          # the leftover cPanel .htaccess artifacts or plugin-managed files.
+          rsync -az --itemize-changes \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='.idea' \
+            --exclude='.env' \
+            ./ "root@${HOST}:${THEME_DIR}/"
+
+      - name: Fix ownership and refresh ACLs
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          ssh "root@${HOST}" "
+            chown -R nginx:nginx '${THEME_DIR}' &&
+            systemctl restart legalizebelarus-org-site-perms
+          "


### PR DESCRIPTION
## Summary
Adds `.github/workflows/deploy.yml` — deploys this theme to the live s1 server automatically on every push to `master` (plus a manual-dispatch button).

### How it works
1. Checks out the repo on an `ubuntu-latest` runner.
2. Loads the **`lb-ci`** deploy key (root-authorized on s1 via the NixOS config) and `ssh-keyscan`s the host.
3. `rsync`s the theme into `…/wp-content/themes/legalizebelarus/`.
4. `chown -R nginx:nginx` + restarts the `legalizebelarus-org-site-perms` ACL service.

A `concurrency` group prevents overlapping deploys.

### Safety
- **Additive sync (no `--delete`)** — prod-only files (e.g. the leftover cPanel `.htaccess` artifacts, plugin-managed files) are never removed. This mirrors the manual deploy already performed.
- Repo meta (`.git`, `.github`, `.idea`, `.env`) is excluded from the upload.

## Required repository secrets (already set)
| Secret | Value |
|---|---|
| `DEPLOY_SSH_KEY` | `lb-ci` private key |
| `DEPLOY_HOST` | s1 host/IP |

## Notes
- Best merged **after** #9 (YARPP templates), so git holds the complete theme before automated deploys begin.
- Deploys run as root on the server. Anyone able to merge to `master` can deploy — add a protected GitHub Environment with a required reviewer if you want a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)